### PR TITLE
Add: Twig extension to pygmentize code directly from templates [WIP]

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -16,5 +16,10 @@
                  parent="kwattro_markdown">
             <argument type="service" id="varspool_pygments" />
         </service>
+
+        <service id="varspool.twig.pygments_extension" class="Varspool\PygmentsBundle\Twig\PygmentsExtension">
+            <argument type="service" id="varspool_pygments"/>
+            <tag name="twig.extension" />
+        </service>
     </services>
 </container>

--- a/Twig/PygmentsExtension.php
+++ b/Twig/PygmentsExtension.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Varspool\PygmentsBundle\Twig;
+
+
+/**
+ * This class contains the following Twig filters:
+ *  * pygmentize($text, $language). Exemple usage {{ some_code|pygmentize('php') }}
+ *
+ * @author Kévin Gomez <contact@kevingomez.fr>
+ */
+class PygmentsExtension extends \Twig_Extension
+{
+    protected $pygments_renderer;
+
+
+    public function __construct($pygments_renderer)
+    {
+        $this->pygments_renderer = $pygments_renderer;
+    }
+
+    public function getFilters()
+    {
+        return array(
+            'pygmentize' => new \Twig_Filter_Method($this, 'pygmentize'),
+        );
+    }
+
+    public function pygmentize($text, $language)
+    {
+        return $this->pygments_renderer->blockCode($text, $language);
+    }
+
+    public function getName()
+    {
+        return 'pygments_extension';
+    }
+}
+


### PR DESCRIPTION
I made a quick twig extension to pygmentize code directly from templates. Before going any further into the development, I'd like to know if this kind of feature is even wanted in your bundle?
If so, I will continue working on it and add a cache layer to avoid calling pygments on each page display (any idea to implement this in a clean way is welcome).

Regards,
Kévin
